### PR TITLE
Fix spacing for latest fastfetch version (2.51.0)

### DIFF
--- a/config.jsonc
+++ b/config.jsonc
@@ -4,8 +4,8 @@
   "logo": {
         "source": "~/.config/fastfetch/cat.txt",
         "type": "auto",
-        "height": 15,
-        "width": 26,
+        "height": 3,
+        "width": 12,
         "padding": {
             "top": 0,
             "left": 2,

--- a/config.jsonc
+++ b/config.jsonc
@@ -9,7 +9,7 @@
         "padding": {
             "top": 0,
             "left": 2,
-            "right": 6
+            "right": 0
         }
     },
   "modules": [


### PR DESCRIPTION
After the update, fastfetch handles padding and spacing differently, reserving the exact number of characters specified, unsure whether or not this works fine on older versions, should be tested before pulling